### PR TITLE
Adding support for :name option without test

### DIFF
--- a/lib/mongoid_auto_increment.rb
+++ b/lib/mongoid_auto_increment.rb
@@ -6,9 +6,11 @@ module MongoidAutoIncrement
   module ClassMethods
     def auto_increment(name, options={})
       field name, :type => Integer
-      seq_name = "#{self.name.downcase}_#{name}"
+
       @@incrementor = MongoidAutoIncrement::Incrementor.new unless defined? @@incrementor
 
+      options ||= {}
+      seq_name = options[:name] || "#{self.name.downcase}_#{name}"
       before_create { self.send("#{name}=", @@incrementor.inc(seq_name, options)) }
     end
   end

--- a/lib/mongoid_auto_increment/incrementor.rb
+++ b/lib/mongoid_auto_increment/incrementor.rb
@@ -58,7 +58,6 @@ module MongoidAutoIncrement
     end
 
     def inc(sequence, options)
-      options ||= {}
       collection = options[:collection] || "sequences"
       seed = options[:seed].to_i
       step = options[:step] || 1


### PR DESCRIPTION
With `name` option you can use multiple documents with same sequence.
