### PR TITLE
[ci skip] Get more Open Source Helpers

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -4,6 +4,7 @@ Add SQL like auto-incrementing fields to your Mongoid documents.
 This gem is inspired by http://ihswebdesign.com/blog/autoincrement-in-mongodb-with-ruby/ and the mongomapper_id2[https://github.com/phstc/mongomapper_id2] gem.
 
 {<img src="https://secure.travis-ci.org/proton/mongoid_auto_increment.png" />}[http://travis-ci.org/proton/mongoid_auto_increment]
+{<img src="https://www.codetriage.com/proton/mongoid_auto_increment/badges/users.svg" />}[https://www.codetriage.com/proton/mongoid_auto_increment]
 
 == Installation
 


### PR DESCRIPTION
[CodeTriage](https://www.codetriage.com/) is an app I have maintained
for the past 4-5 years with the goal of getting people involved in
Open Source projects like this one. The app sends subscribers a random
open issue for them to help "triage". For some languages you can also
suggested areas to add documentation.

The initial approach was inspired by seeing the work of the small
core team spending countless hours asking "what version was
this in" and "can you give us an example app". The idea is to
outsource these small interactions to a huge team of volunteers
and let the core team focus on their work.

I want to add a badge to the README of this project. The idea is to
provide an easy link for people to get started contributing to this
project. A badge indicates the number of people currently subscribed
to help the repo. The color is based off of open issues in the project.

Here are some examples of other projects that have a badge in their
README:

- https://github.com/crystal-lang/crystal
- https://github.com/rails/rails
- https://github.com/codetriage/codetriage

Thanks for building open source software, I would love to help you find some helpers.